### PR TITLE
Remove gfonts css

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -24,7 +24,6 @@
         <!--Style-->
         <link href="{{ url_for('static', filename='css/app.scss.css') }}" rel="stylesheet" type="text/css">
         <link href="{{ url_for('static', filename='css/select2.min.css') }}" rel="stylesheet" type="text/css">
-        <link href="https://fonts.googleapis.com/css?family=PT+Sans+Narrow:400,700&display=swap" rel="stylesheet">
 
         <!--Google Analytics-->
         {% if cookies_check() %}


### PR DESCRIPTION
Page is loading css for some fonts from fonts.googleapis.com. This is slow and sends info to google. The relevant fonts are already statically hosted on our server so is also redundant.