### PR TITLE
Remove main() from generate_data.py until the logging is updated

### DIFF
--- a/app/generate_data.py
+++ b/app/generate_data.py
@@ -934,7 +934,7 @@ def determine_year(day):
     return day.year if math.ceil(day.month/3.) > 2 else day.year-1
 
 
-def main():
+if __name__ == "__main__":
     logpath = os.path.join(os.getcwd(), 'app', 'logging')
     diversity_logger = setup_logging(logpath)
     logfile = diversity_logger.handlers[0].baseFilename
@@ -966,5 +966,3 @@ def main():
         sys.stderr.write(f'generate_data.py failed, see the log for details: {logfile}\n')
     logging.shutdown()
 
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
Follow-up to PRs #40 and #41. `generate_data.py` can't use `main()` until the logging is updated so that it can be passed between functions