### PR TITLE
Resolve Issue #56

### DIFF
--- a/deploy/data.Dockerfile
+++ b/deploy/data.Dockerfile
@@ -3,12 +3,9 @@
 
 FROM python:3.8-slim-buster
 
-RUN apt-get update && apt-get install -y cron
+RUN apt-get update
 
 WORKDIR /app
-
-COPY deploy/cronjob /etc/cron.d/cronjob
-RUN chmod 0644 /etc/cron.d/cronjob && crontab /etc/cron.d/cronjob
 
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+sudo apt-get update -y
+sudo apt-get upgrade -y
+
+#---- docker ----#
+
+# install docker
+sudo apt-get install ca-certificates curl gnupg lsb-release
+
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo apt-get update && sudo apt-get install -y docker-compose
+
+# add user to docker group
+sudo usermod -aG docker ubuntu
+
+# crontab to persist read/write access to docker socket
+sudo crontab -e
+# @reboot chmod a+rw /var/run/docker.sock
+
+
+#---- github ----#
+sudo apt install git
+
+# create GitHub deploy key
+cd ~/.ssh
+ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa <<<n >/dev/null 2>&1
+
+#!! Remember to authorize the deploy key on GitHub
+
+# ssh config for github authentication
+echo "Host github" >> ~/.ssh/config
+echo -e "\tHostName ssh.github.com" >> ~/.ssh/config
+echo -e "\tUser git" >> ~/.ssh/config
+echo -e "\tIdentityFile ~/.ssh/id_rsa" >> ~/.ssh/config
+
+# clone repository
+cd ~
+git clone github:OxfordDemSci/gwasdiversitymonitor
+
+# ---- cron ---- #
+cd ~/gwasdiversitymonitor
+sudo cp deploy/gwasdiversitymonitor_crontab /etc/cron.d/
+
+# ---- launch gwasdiversitymonitor ---- #
+cd ~/gwasdiversitymonitor
+docker-compose up -d

--- a/deploy/gwasdiversitymonitor_crontab
+++ b/deploy/gwasdiversitymonitor_crontab
@@ -2,4 +2,4 @@
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin/python3
 # m h dom mon dow user  command
-0 0 * * * root python3 /app/generate_data.py
+@daily ubuntu cd ~/gwasdiversitymonitor; docker-compose up -d data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,17 +32,17 @@ services:
           - flask-app
     restart: unless-stopped
 
-  cron:
-    container_name: gwas_cron
+  data:
+    container_name: gwas_data
     build:
       context: ./
-      dockerfile: deploy/cron.Dockerfile
-    command: ["python3", "generate_data.py", "&&", "cron", "-f"]
+      dockerfile: deploy/data.Dockerfile
+    command: ["python3", "generate_data.py"]
     volumes:
       - ./data:/app/data
     networks:
       - my-network
-    restart: unless-stopped
+    restart: on-failure
 
 networks:
   my-network:


### PR DESCRIPTION
This pull request moves the cron scheduler for generate_data.py from the container to the host machine. The container that runs generate_data.py will now close as soon as it finished and then the host's cron will relaunch it daily. This should resolve issue #56.

I also added a deploy.sh shell script to document the steps for setting up the host (although it probably needs to be tweaked next time we redeploy to a new vm).